### PR TITLE
Some EoG detection (#11)

### DIFF
--- a/src/search/definitions.rs
+++ b/src/search/definitions.rs
@@ -1,2 +1,3 @@
 pub const MAX_PLY: u8 = 128;
 pub const INFINITY: i16 = 32_001;
+pub const MATE: i16 = 32_000;

--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -1,11 +1,11 @@
 use super::{
-    definitions::{INFINITY, MAX_PLY},
+    definitions::{INFINITY, MATE, MAX_PLY},
     eval::eval,
     options::SearchOptions,
     pv_table::PVTable,
 };
 use crate::{chess::move_gen, search::timeman::timeman};
-use cozy_chess::{Board, Move};
+use cozy_chess::{Board, GameStatus, Move};
 use std::time::Instant;
 
 pub struct SearchInfo {
@@ -67,6 +67,12 @@ pub fn search(
 
     if depth == 0 {
         return eval(board);
+    }
+
+    match board.status() {
+        GameStatus::Won => return mated_in(ply),
+        GameStatus::Drawn => return draw_score(),
+        _ => (),
     }
 
     let mut best_score = -INFINITY;
@@ -158,4 +164,176 @@ pub fn search_root(info: &mut SearchInfo, board: &Board, option: SearchOptions, 
     }
 
     println!("bestmove {}", best_move.unwrap());
+}
+
+fn draw_score() -> i16 {
+    0
+}
+
+fn mated_in(ply: u8) -> i16 {
+    -MATE + ply as i16
+}
+
+fn mate_in(ply: u8) -> i16 {
+    MATE - ply as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mate_in_1() {
+        const TESTS: [(&str, &str); 3] = [
+            (
+                "4r2k/1p3rbp/2p1N1p1/p3n3/P2NB1nq/1P6/4R1P1/B1Q2RK1 b - - 4 32",
+                "h4h2",
+            ),
+            (
+                "4rb2/3qrk2/1p1p1n2/7p/P2P4/4R2P/1BQN1P2/1K4R1 w - - 3 39",
+                "c2g6",
+            ),
+            (
+                "r1bqkbnr/pp2pp1p/3p2p1/2p5/3nP3/2N3PP/PPP1NP2/R1BQKB1R b KQkq - 1 6",
+                "d4f3",
+            ),
+        ];
+
+        for (fen, mv) in TESTS.iter() {
+            let mut info = SearchInfo::new();
+            let mut pv = PVTable::new();
+
+            let score = search(
+                &mut info,
+                -INFINITY,
+                INFINITY,
+                &fen.parse().unwrap(),
+                3,
+                0,
+                &mut pv,
+            );
+
+            assert_eq!(score, mate_in(1));
+            assert_eq!(pv.table[0], Some(mv.parse().unwrap()));
+        }
+    }
+
+    #[test]
+    fn mated_in_1() {
+        const TESTS: [(&str, &str); 2] = [
+            ("8/8/8/8/8/1k6/4r3/K7 w - - 0 1", "a1b1"),
+            ("k7/1pR4R/8/Q7/8/8/8/7K b - - 0 1", "a8b8"),
+        ];
+
+        for (fen, mv) in TESTS.iter() {
+            let mut info = SearchInfo::new();
+            let mut pv = PVTable::new();
+
+            let score = search(
+                &mut info,
+                -INFINITY,
+                INFINITY,
+                &fen.parse().unwrap(),
+                3,
+                0,
+                &mut pv,
+            );
+
+            assert_eq!(score, mated_in(2));
+            assert_eq!(pv.table[0], Some(mv.parse().unwrap()));
+        }
+    }
+
+    #[test]
+    fn mate_in_2() {
+        const TESTS: [(&str, &str); 3] = [
+            (
+                "4r3/1pp2rbk/6pn/4n3/P3BN1q/1PB2bPP/8/2Q1RRK1 b - - 0 31",
+                "h4g3",
+            ),
+            (
+                "r2k1b1r/p1ppq2p/np3np1/5p2/1PPP4/P3PQ2/3N1PPP/R1B1K2R w KQ - 1 13",
+                "f3a8",
+            ),
+            (
+                "rn3r2/p2q1pBk/1p2p3/3pP3/P1bNnQ2/5NP1/1P3PBP/R3b1K1 w - - 1 19",
+                "f4h6",
+            ),
+        ];
+
+        for (fen, mv) in TESTS.iter() {
+            let mut info = SearchInfo::new();
+            let mut pv = PVTable::new();
+
+            let score = search(
+                &mut info,
+                -INFINITY,
+                INFINITY,
+                &fen.parse().unwrap(),
+                5,
+                0,
+                &mut pv,
+            );
+
+            assert_eq!(score, mate_in(3));
+            assert_eq!(pv.table[0], Some(mv.parse().unwrap()));
+        }
+    }
+
+    #[test]
+    fn mated_in_2() {
+        const TESTS: [(&str, &str); 2] = [
+            (
+                "r1bq1bkr/ppp3pp/2n5/3Qp3/2B5/8/PPPP1PPP/RNB1K2R b KQ - 0 8",
+                "d8d5",
+            ),
+            (
+                "rnb1k2r/pppp1ppp/8/2b5/3qP3/P1N5/1PP3PP/R1BQ1BKR w kq - 0 9",
+                "d1d4",
+            ),
+        ];
+
+        for (fen, mv) in TESTS.iter() {
+            let mut info = SearchInfo::new();
+            let mut pv = PVTable::new();
+
+            let score = search(
+                &mut info,
+                -INFINITY,
+                INFINITY,
+                &fen.parse().unwrap(),
+                5,
+                0,
+                &mut pv,
+            );
+
+            assert_eq!(score, mated_in(4));
+            assert_eq!(pv.table[0], Some(mv.parse().unwrap()));
+        }
+    }
+
+    #[test]
+    fn draw_50mr() {
+        const TESTS: [&str; 2] = [
+            "7k/6n1/8/8/8/8/1N6/K7 w - - 99 6969",
+            "nnn5/n1nn4/nnnn4/n1n5/7k/8/7K/8 w - - 99 6969",
+        ];
+
+        for fen in TESTS.iter() {
+            let mut info = SearchInfo::new();
+            let mut pv = PVTable::new();
+
+            let score = search(
+                &mut info,
+                -INFINITY,
+                INFINITY,
+                &fen.parse().unwrap(),
+                5,
+                0,
+                &mut pv,
+            );
+
+            assert_eq!(score, 0);
+        }
+    }
 }


### PR DESCRIPTION
Score of honse-eog vs honse: 62 - 20 - 109  [0.610] 191
...      honse-eog playing White: 34 - 11 - 51  [0.620] 96
...      honse-eog playing Black: 28 - 9 - 58  [0.600] 95
...      White vs Black: 43 - 39 - 109  [0.510] 191
Elo difference: 77.7 +/- 32.0, LOS: 100.0 %, DrawRatio: 57.1 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted